### PR TITLE
fix clean_input for UploadType

### DIFF
--- a/graphene_django_plus/mutations.py
+++ b/graphene_django_plus/mutations.py
@@ -136,11 +136,6 @@ def _is_id_field(field):
     )
 
 
-def _is_upload_field(field):
-    t = getattr(field.type, 'of_type', field.type)
-    return t == UploadType
-
-
 class BaseMutationOptions(MutationOptions):
     """Model type options for :class:`BaseMutation` and subclasses."""
 
@@ -502,10 +497,6 @@ class ModelMutation(BaseModelMutation):
                 # ID field
                 instance = cls.get_node(info, value, f_name)
                 cleaned_input[f_name] = instance
-            elif value is not None and _is_upload_field(f_item):
-                # uploaded files
-                value = info.context.FILES.get(value)
-                cleaned_input[f_name] = value
             else:
                 # other fields
                 cleaned_input[f_name] = value


### PR DESCRIPTION
currently uploadType for mutations is not working. I use custome parse_body do get files. 
```
    def parse_body(self, request):
        """ We write our own parser for media, since it is not supported in GraphQL itself """
        content_type = self.get_content_type(request)
        if content_type == 'multipart/form-data':
            operations = json.loads(request.POST.get('operations', '{}'))
            files_map = json.loads(request.POST.get('map', '{}'))
            return place_files_in_operations(
                operations,
                files_map,
                request.FILES
            )
        return super(SafeGraphQLView, self).parse_body(request)
``` 
from https://github.com/lmcgartland/graphene-file-upload/


Can you share what do you use to resolve media files?
or any tests for UploadTypes?