### PR TITLE
fix required fields with default value in create mutation

### DIFF
--- a/graphene_django_plus/mutations.py
+++ b/graphene_django_plus/mutations.py
@@ -14,6 +14,7 @@ from django.db import (
     models,
     transaction,
 )
+from django.db.models.fields import NOT_PROVIDED
 from django.db.models.fields.reverse_related import (
     ManyToOneRel,
     ManyToManyRel,
@@ -178,7 +179,7 @@ def _get_fields(model, only_fields, exclude_fields, required_fields):
             if isinstance(field, (ManyToOneRel, ManyToManyRel)):
                 f.kwargs["required"] = not field.null
             else:
-                f.kwargs["required"] = not field.blank and field.default is django.db.models.fields.NOT_PROVIDED
+                f.kwargs["required"] = not field.blank and field.default is NOT_PROVIDED
 
         if getattr(field, "choices", None):
             items = field.choices

--- a/graphene_django_plus/mutations.py
+++ b/graphene_django_plus/mutations.py
@@ -178,7 +178,7 @@ def _get_fields(model, only_fields, exclude_fields, required_fields):
             if isinstance(field, (ManyToOneRel, ManyToManyRel)):
                 f.kwargs["required"] = not field.null
             else:
-                f.kwargs["required"] = not field.blank
+                f.kwargs["required"] = not field.blank and field.default is django.db.models.fields.NOT_PROVIDED
 
         if getattr(field, "choices", None):
             items = field.choices


### PR DESCRIPTION
When use a create mutation, the required fields should include those not null or not blank as well as no default value field.