### PR TITLE
Register input types for model fields

### DIFF
--- a/graphene_django_plus/input_types.py
+++ b/graphene_django_plus/input_types.py
@@ -5,9 +5,10 @@ used in mutations.
 import functools
 from typing import Union
 
-import graphene
 from django.db import models
-from django.db.models import Field, ForeignObjectRel
+from django.db.models import Field
+from django.db.models.fields.reverse_related import ForeignObjectRel
+import graphene
 from graphene import Scalar
 from graphene.types.structures import Structure
 from graphene_django.converter import convert_django_field_with_choices
@@ -17,7 +18,9 @@ from .types import UploadType
 
 
 @functools.singledispatch
-def get_input_field(field: Union[Field, ForeignObjectRel], registry: Registry) -> Union[Scalar, Structure]:
+def get_input_field(
+    field: Union[Field, ForeignObjectRel], registry: Registry
+) -> Union[Scalar, Structure]:
     """
     Convert a model field into a GraphQL input type used in mutations.
     :param field: A model field.

--- a/graphene_django_plus/input_types.py
+++ b/graphene_django_plus/input_types.py
@@ -1,0 +1,67 @@
+"""
+Module that defines the mapping between model fields and GraphQL input types
+used in mutations.
+"""
+import functools
+from typing import Union
+
+import graphene
+from django.db import models
+from django.db.models import Field, ForeignObjectRel
+from graphene import Scalar
+from graphene.types.structures import Structure
+from graphene_django.converter import convert_django_field_with_choices
+from graphene_django.registry import Registry
+
+from .types import UploadType
+
+
+@functools.singledispatch
+def get_input_field(field: Union[Field, ForeignObjectRel], registry: Registry) -> Union[Scalar, Structure]:
+    """
+    Convert a model field into a GraphQL input type used in mutations.
+    :param field: A model field.
+    :param registry: Registry which holds a mapping between django models/fields
+      and Graphene types.
+    :return: A scalar that can be used as an input field in mutations.
+    """
+    return convert_django_field_with_choices(field, registry)
+
+
+@get_input_field.register(models.FileField)
+def get_file_field(field, registry):
+    return UploadType(
+        description=field.help_text,
+    )
+
+
+@get_input_field.register(models.BooleanField)
+def get_boolean_field(field, registry):
+    return graphene.Boolean(
+        description=field.help_text,
+    )
+
+
+@get_input_field.register(models.ForeignKey)
+@get_input_field.register(models.OneToOneField)
+def get_foreign_key_field(field, registry):
+    return graphene.ID(
+        description=field.help_text,
+    )
+
+
+@get_input_field.register(models.ManyToManyField)
+def get_many_to_many_field(field, registry):
+    return graphene.List(
+        graphene.ID,
+        description=field.help_text,
+    )
+
+
+@get_input_field.register(models.ManyToOneRel)
+@get_input_field.register(models.ManyToManyRel)
+def get_relation_field(field, registry):
+    return graphene.List(
+        graphene.ID,
+        description="Set list of {}".format(field.related_model._meta.verbose_name_plural),
+    )

--- a/tests/test_input_types.py
+++ b/tests/test_input_types.py
@@ -1,8 +1,9 @@
-import graphene
 from django.db import models
+import graphene
 from graphene_django.registry import get_global_registry
 
 from graphene_django_plus.input_types import get_input_field
+
 from .base import BaseTestCase
 from .models import Project
 
@@ -40,9 +41,9 @@ class TestInputTypes(BaseTestCase):
         field = models.ManyToOneRel(
             models.ForeignKey(Project, on_delete=models.CASCADE), Project, "projects"
         )
-        setattr(
-            field, "related_model", Project
-        )  # set this manually because django does not initialize the model
+        field.related_model = (
+            Project  # set this manually because django does not initialize the model
+        )
         input_field = get_input_field(field, _registry)
         self.assertTrue(isinstance(input_field, graphene.List))
         self.assertEqual(input_field.of_type._meta.name, "ID")
@@ -51,9 +52,9 @@ class TestInputTypes(BaseTestCase):
         field = models.ManyToManyRel(
             models.ForeignKey(Project, on_delete=models.CASCADE), Project, "projects"
         )
-        setattr(
-            field, "related_model", Project
-        )  # set this manually because django does not initialize the model
+        field.related_model = (
+            Project  # set this manually because django does not initialize the model
+        )
         input_field = get_input_field(field, _registry)
         self.assertTrue(isinstance(input_field, graphene.List))
         self.assertEqual(input_field.of_type._meta.name, "ID")

--- a/tests/test_input_types.py
+++ b/tests/test_input_types.py
@@ -21,6 +21,11 @@ class TestInputTypes(BaseTestCase):
         input_field = get_input_field(field, _registry)
         self.assertEqual(input_field._meta.name, "Boolean")
 
+    def test_file(self):
+        field = models.FileField()
+        input_field = get_input_field(field, _registry)
+        self.assertEqual(input_field._meta.name, "UploadType")
+
     def test_foreign_key(self):
         field = models.ForeignKey(Project, on_delete=models.CASCADE)
         input_field = get_input_field(field, _registry)

--- a/tests/test_input_types.py
+++ b/tests/test_input_types.py
@@ -1,0 +1,59 @@
+import graphene
+from django.db import models
+from graphene_django.registry import get_global_registry
+
+from graphene_django_plus.input_types import get_input_field
+from .base import BaseTestCase
+from .models import Project
+
+_registry = get_global_registry()
+
+
+class TestInputTypes(BaseTestCase):
+    def test_char(self):
+        field = models.CharField()
+        input_field = get_input_field(field, _registry)
+        self.assertEqual(input_field._meta.name, "String")
+
+    def test_boolean(self):
+        field = models.BooleanField()
+        input_field = get_input_field(field, _registry)
+        self.assertEqual(input_field._meta.name, "Boolean")
+
+    def test_foreign_key(self):
+        field = models.ForeignKey(Project, on_delete=models.CASCADE)
+        input_field = get_input_field(field, _registry)
+        self.assertEqual(input_field._meta.name, "ID")
+
+    def test_one_to_one(self):
+        field = models.OneToOneField(Project, on_delete=models.CASCADE)
+        input_field = get_input_field(field, _registry)
+        self.assertEqual(input_field._meta.name, "ID")
+
+    def test_many_to_many(self):
+        field = models.ManyToManyField(Project)
+        input_field = get_input_field(field, _registry)
+        self.assertTrue(isinstance(input_field, graphene.List))
+        self.assertEqual(input_field.of_type._meta.name, "ID")
+
+    def test_many_to_one_relation(self):
+        field = models.ManyToOneRel(
+            models.ForeignKey(Project, on_delete=models.CASCADE), Project, "projects"
+        )
+        setattr(
+            field, "related_model", Project
+        )  # set this manually because django does not initialize the model
+        input_field = get_input_field(field, _registry)
+        self.assertTrue(isinstance(input_field, graphene.List))
+        self.assertEqual(input_field.of_type._meta.name, "ID")
+
+    def test_many_to_many_relation(self):
+        field = models.ManyToManyRel(
+            models.ForeignKey(Project, on_delete=models.CASCADE), Project, "projects"
+        )
+        setattr(
+            field, "related_model", Project
+        )  # set this manually because django does not initialize the model
+        input_field = get_input_field(field, _registry)
+        self.assertTrue(isinstance(input_field, graphene.List))
+        self.assertEqual(input_field.of_type._meta.name, "ID")


### PR DESCRIPTION
Right now the input fields for the mutations are returned from the method `_get_fields`. Depending on the model field class, it returns a certain type of graphene scalar to be used as input type. This PR moves that logic into a function called `get_input_type` which provides different variants for different model fields. This makes it possible to register new input types for custom model fields.